### PR TITLE
Only execute root once

### DIFF
--- a/src/main/java/io/hgc/jarspec/JarSpecJUnitRunner.java
+++ b/src/main/java/io/hgc/jarspec/JarSpecJUnitRunner.java
@@ -17,12 +17,13 @@ import java.util.Optional;
  */
 public class JarSpecJUnitRunner<T extends Specification> extends Runner {
     private Class<T> specClass;
-    private T specification;
+    private SpecificationNode rootSpecification;
 
     public JarSpecJUnitRunner(Class<T> specClass) throws InstantiationException {
         this.specClass = specClass;
         try {
-            specification = specClass.newInstance();
+            T specification = specClass.newInstance();
+            rootSpecification = specification.root();
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }
@@ -30,17 +31,17 @@ public class JarSpecJUnitRunner<T extends Specification> extends Runner {
 
     @Override
     public Description getDescription() {
-        return visitTree(specification.root(), Optional.empty());
+        return visitTree(rootSpecification, Optional.empty());
     }
 
     @Override
     public void run(RunNotifier notifier) {
-        visitTree(specification.root(), Optional.of(notifier));
+        visitTree(rootSpecification, Optional.of(notifier));
     }
 
     private Description visitTree(SpecificationNode specificationNode, Optional<RunNotifier> notifier) {
         Description description = Description.createTestDescription(specClass, specificationNode.description());
-        visitTree(specification.root(), notifier, "").forEach(description::addChild);
+        visitTree(rootSpecification, notifier, "").forEach(description::addChild);
         return description;
     }
 

--- a/src/test/java/io/hgc/jarspec/JarSpecJUnitRunnerSpec.java
+++ b/src/test/java/io/hgc/jarspec/JarSpecJUnitRunnerSpec.java
@@ -3,7 +3,7 @@ package io.hgc.jarspec;
 import io.hgc.jarspec.examples.AdditionSpec;
 import io.hgc.jarspec.examples.AssumptionFailureSpec;
 import io.hgc.jarspec.examples.ErrorInDescribeSpec;
-import io.hgc.jarspec.examples.ExceptionSpec;
+import io.hgc.jarspec.examples.ErrorInRootSpec;
 import org.junit.runner.*;
 import org.junit.runner.notification.Failure;
 
@@ -79,6 +79,17 @@ public class JarSpecJUnitRunnerSpec implements Specification, ExceptionBehaviour
                         it("allows other statements in the same spec to proceed", () ->
                             assertTrue(result.getFailureCount() < result.getRunCount()))
                     );
+                }),
+                describe("root error", () -> {
+                    Result result = new JUnitCore().run(ErrorInRootSpec.class);
+
+                    return it("causes a single init failure for spec class", () -> {
+                        assertEquals(1, result.getFailureCount());
+                        Failure failure = result.getFailures().get(0);
+                        String displayName = failure.getDescription().getDisplayName();
+                        assertTrue(displayName.contains("initializationError"));
+                        assertTrue(displayName.contains(ErrorInRootSpec.class.getName()));
+                    });
                 })
             );
         });

--- a/src/test/java/io/hgc/jarspec/examples/ErrorInRootSpec.java
+++ b/src/test/java/io/hgc/jarspec/examples/ErrorInRootSpec.java
@@ -1,0 +1,14 @@
+package io.hgc.jarspec.examples;
+
+import io.hgc.jarspec.JarSpecJUnitRunner;
+import io.hgc.jarspec.Specification;
+import io.hgc.jarspec.SpecificationNode;
+import org.junit.runner.RunWith;
+
+@RunWith(JarSpecJUnitRunner.class)
+public class ErrorInRootSpec implements Specification {
+    @Override
+    public SpecificationNode root() {
+        throw new RuntimeException("Test exception thrown before SpecificationNode returned");
+    }
+}


### PR DESCRIPTION
Just having a quick play, really, 'cos this looked like fun! I realise you're still chucking ideas around, etc, so feel free to completely ignore this. I just happened to notice it whilst I was playing around!

Prior to this change, testInstance.root() gets executed a lot - it feels like, as a consumer of jarspec, that would be very surprising to me: if I had any code in there that wasn't idempotent, it could cause me problems.

One thought having just re-read my change though: will I have broken error handling somehow? Exceptions thrown by executing root() will now happen when the runner is constructed, rather than when getDescription/run are called. I guess the idea is that root() doesn't throw exceptions (because all the actual test code is in the various lambdas)?

Good luck with this - interesting idea, even if it doesn't pan out!
